### PR TITLE
Removed caching the object. Was causing errors.

### DIFF
--- a/mixin.js
+++ b/mixin.js
@@ -7,7 +7,6 @@ module.exports = _isUndefined = function(obj) {
         if(!obj.hasOwnProperty(arguments[i])) {
             return true;
         }
-        obj = obj[arguments[i]];
     };
     return false;
 };


### PR DESCRIPTION
If the object is empty it will return true, however if there is more
than one property e.g. from, to. It will cause the whole check to fail.
This will still work if there is another object defined inside the
options object.
