### PR TITLE
Update repository name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": "https://github.com/log0ymxm/harvest-node",
+  "repository": "https://github.com/log0ymxm/node-harvest",
   "author": "Paul English",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The [npmjs.org page](https://npmjs.org/package/harvest) has outdated info.
