### PR TITLE
fix for 'Use emitter.setMaxListeners() to increase limit' issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = Harvest = function (opts) {
             throw new Error('processRequest: Callback is not defined');
         }
 
-        res.addListener('complete', function (data, res) {
+        res.once('complete', function (data, res) {
             var err;
 
             if (self.debug) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "request": "~2.12.0",
-    "restler": "~2.0.1"
+    "restler": "~3.1.0"
   },
   "devDependencies": {
     "mocha": "~1.7.0",


### PR DESCRIPTION
I uncovered an issue when calling the api repeatedly that a couple of things would happen:
1. the listener would fire for requests i wasn't invoking (moved to use the once instead of addListener below)
2. the eventEmitter would complain for too many leaks (issue in restler pre 3.1.0)

this fixes both of these scenarios
