### PR TITLE
Added time-tracking calls on other users.

### DIFF
--- a/lib/time-tracking.js
+++ b/lib/time-tracking.js
@@ -18,6 +18,12 @@ TimeTracking.prototype.daily = function (options, cb) {
         url += '/' + day_of_year + '/' + options.date.getFullYear();
     }
 
+    if(!_isUndefined(options, 'of_user')) {
+        url += '?of_user=#' + options.of_user;
+
+        delete options.of_user;
+    }
+
     this.client.get(url, {}, cb);
 };
 
@@ -25,8 +31,15 @@ TimeTracking.prototype.get = function (options, cb) {
     if (_isUndefined(options, 'id')) {
         return cb(new Error('getting daily time requires an id'));
     }
-
+    
     var url = '/daily/show/' + options.id;
+
+    if(!_isUndefined(options, 'of_user')) {
+        url += '?of_user=#' + options.of_user;
+
+        delete options.of_user;
+    }
+
     this.client.get(url, {}, cb);
 };
 
@@ -34,13 +47,27 @@ TimeTracking.prototype.toggleTimer = function (options, cb) {
     if (_isUndefined(options, 'id')) {
         return cb(new Error('toggling the timer requires an id'));
     }
-
+    
     var url = '/daily/timer/' + options.id;
+
+    if(!_isUndefined(options, 'of_user')) {
+        url += '?of_user=#' + options.of_user;
+
+        delete options.of_user;
+    }
+    
     this.client.get(url, {}, cb);
 };
 
 TimeTracking.prototype.create = function (options, cb) {
     var url = '/daily/add';
+
+    if(!_isUndefined(options, 'of_user')) {
+        url += '?of_user=#' + options.of_user;
+
+        delete options.of_user;
+    }
+
     this.client.post(url, options, cb);
 };
 
@@ -50,6 +77,13 @@ TimeTracking.prototype.delete = function (options, cb) {
     }
 
     var url = '/daily/delete/' + options.id;
+
+    if(!_isUndefined(options, 'of_user')) {
+        url += '?of_user=#' + options.of_user;
+
+        delete options.of_user;
+    }
+
     this.client.delete(url, {}, cb);
 };
 
@@ -59,6 +93,13 @@ TimeTracking.prototype.update = function (options, cb) {
     }
 
     var url = '/daily/update/' + options.id;
+
+    if(!_isUndefined(options, 'of_user')) {
+        url += '?of_user=#' + options.of_user;
+
+        delete options.of_user;
+    }
+
     delete options.id;
     this.client.post(url, options, cb);
 };


### PR DESCRIPTION
Time-tracking API supports calls on other users. If the authenticated user is an admin, you can add the option of_user with a user id to all the Time-tracking calls to apply the call to that user instead of the authenticated one.
