### PR TITLE
Remove hash in front of "of_user" in time-tracking.js

### DIFF
--- a/lib/time-tracking.js
+++ b/lib/time-tracking.js
@@ -19,7 +19,7 @@ TimeTracking.prototype.daily = function (options, cb) {
     }
 
     if(!_isUndefined(options, 'of_user')) {
-        url += '?of_user=#' + options.of_user;
+        url += '?of_user=' + options.of_user;
 
         delete options.of_user;
     }
@@ -35,7 +35,7 @@ TimeTracking.prototype.get = function (options, cb) {
     var url = '/daily/show/' + options.id;
 
     if(!_isUndefined(options, 'of_user')) {
-        url += '?of_user=#' + options.of_user;
+        url += '?of_user=' + options.of_user;
 
         delete options.of_user;
     }
@@ -51,7 +51,7 @@ TimeTracking.prototype.toggleTimer = function (options, cb) {
     var url = '/daily/timer/' + options.id;
 
     if(!_isUndefined(options, 'of_user')) {
-        url += '?of_user=#' + options.of_user;
+        url += '?of_user=' + options.of_user;
 
         delete options.of_user;
     }
@@ -63,7 +63,7 @@ TimeTracking.prototype.create = function (options, cb) {
     var url = '/daily/add';
 
     if(!_isUndefined(options, 'of_user')) {
-        url += '?of_user=#' + options.of_user;
+        url += '?of_user=' + options.of_user;
 
         delete options.of_user;
     }
@@ -79,7 +79,7 @@ TimeTracking.prototype.delete = function (options, cb) {
     var url = '/daily/delete/' + options.id;
 
     if(!_isUndefined(options, 'of_user')) {
-        url += '?of_user=#' + options.of_user;
+        url += '?of_user=' + options.of_user;
 
         delete options.of_user;
     }
@@ -95,7 +95,7 @@ TimeTracking.prototype.update = function (options, cb) {
     var url = '/daily/update/' + options.id;
 
     if(!_isUndefined(options, 'of_user')) {
-        url += '?of_user=#' + options.of_user;
+        url += '?of_user=' + options.of_user;
 
         delete options.of_user;
     }


### PR DESCRIPTION
The hash as far as I can tell is not supposed to be included in requests to the Harvest API: https://github.com/harvesthq/api/blob/master/Sections/Time%20Tracking.md#working-with-timesheets-for-other-users

This removes the hash in front of `of_user` in time-tracking.js
