### PR TITLE
added back the ofUser stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ harvest.projects.list({}, function(error, res, body) {
   - `update(id, {params}, callback)`
   - `delete(id, callback)`
   - `attachReceipt(id, {params}, callback)`
-  - `getReceipt(id, callback)`
+  - `getReceipt(id, {params}, callback)`
 - invoiceCategories
   - `list({params}, callback)`
   - `get(id, callback)`
@@ -168,7 +168,7 @@ harvest.projects.list({}, function(error, res, body) {
   - `activate(id, callback)`
 - timeTracking
   - `daily({params}, callback)`
-  - `get(id, callback)`
+  - `get(id, {params}, callback)`
   - `create({params}, callback)`
   - `update(id, {params}, callback)`
   - `delete(id, callback)`

--- a/lib/api/expenses.js
+++ b/lib/api/expenses.js
@@ -23,6 +23,7 @@ assign(Expenses.prototype, apiBase);
 
 /**
  * [attachReceipt description]
+ * @param  {[type]}   id      [description]
  * @param  {[type]}   options [description]
  * @param  {Function} cb      [description]
  * @return {[type]}           [description]
@@ -58,16 +59,18 @@ Expenses.prototype.attachReceipt = function(id, options, cb) {
 
 /**
  * [getReceipt description]
+ * @param  {[type]}   id      [description]
  * @param  {[type]}   options [description]
  * @param  {Function} cb      [description]
  * @return {[type]}           [description]
  */
-Expenses.prototype.getReceipt = function(id, cb) {
+Expenses.prototype.getReceipt = function(id, options, cb) {
   if (!id) {
     return cb(new Error('getting a receipt requires an id'));
   }
 
   let uri = this.baseUri + id + '/receipt';
+  uri = helpers.ofUserUri(uri, options);
 
   this.harvest.request('GET', uri, {}, cb);
 };

--- a/lib/api/time-tracking.js
+++ b/lib/api/time-tracking.js
@@ -31,16 +31,18 @@ TimeTracking.prototype.daily = function(options, cb) {
 
 /**
  * [get description]
+ * @param  {[type]}   id [description]
  * @param  {[type]}   options [description]
  * @param  {Function} cb      [description]
  * @return {[type]}           [description]
  */
-TimeTracking.prototype.get = function(id, cb) {
+TimeTracking.prototype.get = function(id, options, cb) {
   if (!id) {
     return cb(new Error('getting daily time requires an id'));
   }
 
   let uri = `/daily/show/${id}`;
+  uri = helpers.ofUserUri(uri, options)
 
   this.harvest.request('GET', uri, {}, cb);
 };
@@ -53,6 +55,7 @@ TimeTracking.prototype.get = function(id, cb) {
  */
 TimeTracking.prototype.create = function(options, cb) {
   let uri = '/daily/add';
+  uri = helpers.ofUserUri(uri, options);
 
   this.harvest.request('POST', uri, options, cb);
 };
@@ -69,6 +72,8 @@ TimeTracking.prototype.update = function(id, options, cb) {
   }
 
   let uri = `/daily/update/${id}`;
+
+  helpers.ofUserUri(uri, options);
 
   this.harvest.request('POST', uri, options, cb);
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const appendQuery = require('append-query');
 const _has = require('lodash/has');
 
 const helpers = {
   dayOfYear: dayOfYear,
   getId: getId,
-  has: has
+  has: has,
+  ofUserUri: ofUserUri
 };
 
 module.exports = helpers;
@@ -53,4 +55,14 @@ function has(object, properties) {
     }
   }
   return true;
+}
+
+function ofUserUri(url, options) {
+  if (options.of_user) {
+    url = appendQuery(url, {
+      of_user: options.of_user
+    });
+    delete options.of_user;
+  }
+  return url;
 }

--- a/lib/mixins/api-base.js
+++ b/lib/mixins/api-base.js
@@ -15,6 +15,7 @@ const apiBase = {
    */
   list(options, cb) {
     let uri = this.baseUri;
+    uri = helpers.ofUserUri(uri, options)
 
     this.harvest.request('GET', uri, options, cb);
   },
@@ -43,6 +44,7 @@ const apiBase = {
    */
   create(options, cb) {
     let uri = this.baseUri;
+    uri = helpers.ofUserUri(uri, options)
 
     this.harvest.request('POST', uri, options, cb);
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "main": "./lib/harest.js",
   "dependencies": {
+    "append-query": "^2.0.1",
     "async": "^2.1.4",
     "lodash": "^4.17.4",
     "request": "^2.79.0"

--- a/test/expenses-api-tests.js
+++ b/test/expenses-api-tests.js
@@ -58,12 +58,12 @@ describe('The Expenses API', function() {
       assert.equal(typeof harvest.expenses.getReceipt, 'function');
     });
     it('should should return an error when valid ids', function() {
-      harvest.expenses.getReceipt(null, function(err, res, entries) {
+      harvest.expenses.getReceipt(null, {}, function(err, res, entries) {
         assert(typeof err.message === 'string');
       });
     });
     it('should work properly', function(done) {
-      harvest.expenses.getReceipt(15113947, function(err, res, results) {
+      harvest.expenses.getReceipt(15113947, {}, function(err, res, results) {
         assert(!err);
         done();
       });

--- a/test/helpers-tests.js
+++ b/test/helpers-tests.js
@@ -41,4 +41,22 @@ describe('Helpers', function() {
       assert(!helpers.has(object, ['missing']));
     });
   });
+  describe('ofUserUri', function() {
+    let url = 'http://localhost';
+    let options = {
+      of_user: 'userID'
+    };
+    it('be a function', function() {
+      assert.equal(typeof helpers.ofUserUri, 'function');
+    });
+    it('should return submitted url if of_user is not defined', function() {
+      assert.equal(url, helpers.ofUserUri(url, {}));
+    });
+    it('should an appended url with the of user parameter set', function() {
+      assert.equal(url + '/?of_user=userID', helpers.ofUserUri(url, options));
+    });
+    it('should delete the of_user property if defined', function() {
+      assert.equal(typeof options.of_user, 'undefined');
+    });
+  });
 });

--- a/test/time-tracking-api-tests.js
+++ b/test/time-tracking-api-tests.js
@@ -128,12 +128,12 @@ describe('The TimeTracking API', function() {
       assert.equal(typeof harvest.timeTracking.get, 'function');
     });
     it('should return an error when missing valid ids', function() {
-      harvest.timeTracking.get(null, function(err, res, entries) {
+      harvest.timeTracking.get(null, {}, function(err, res, entries) {
         assert(err.message === 'getting daily time requires an id');
       });
     });
     it('should return an individual timer', function(done) {
-      harvest.timeTracking.get(TEST_TIMER_ID, function(err, responce, timer) {
+      harvest.timeTracking.get(TEST_TIMER_ID, {}, function(err, responce, timer) {
         assert(!err);
         assert.equal(typeof timer, 'object');
         assert.equal(typeof timer.id, 'number');

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+append-query@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/append-query/-/append-query-2.0.1.tgz#d996a5954c3746b00ced7b36fa1ee2f023642025"
+  dependencies:
+    extend "^1.3.0"
+
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
@@ -492,6 +498,10 @@ event-emitter@~0.3.5:
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+
+extend@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-1.3.0.tgz#d1516fb0ff5624d2ebf9123ea1dac5a1994004f8"
 
 extend@~3.0.0:
   version "3.0.1"


### PR DESCRIPTION
As stated [in the commit 9e644184ba894ed7d2b0ee99b94fe0ad301f9fff](/log0ymxm/node-harvest/commit/9e644184ba894ed7d2b0ee99b94fe0ad301f9fff#commitcomment-24022317), removing the `ofUser` functions forbids to manage expenses and time-trackings for other users.

This PR adds back this feature. It implies some method-signature changes. The according tests and documentation have been fixed. 