### PR TITLE
fix(Fixes #97): Updated name to RequestClient

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1,5 +1,5 @@
 import * as Request from 'request-promise';
-import Client from './client';
+import RequestClient from './client';
 
 const config = {
   subdomain: process.env.SUBDOMAIN,
@@ -17,11 +17,11 @@ describe('Client test', () => {
   let instance;
 
   beforeEach(() => {
-    instance = new Client(config);
+    instance = new RequestClient(config);
   });
 
   it('Client is instantiable', () => {
-    expect(instance).toBeInstanceOf(Client);
+    expect(instance).toBeInstanceOf(RequestClient);
   });
 
   describe('preprocess method', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import async from 'async';
 import * as Request from 'request-promise';
 
-export default class Client {
+export default class RequestClient {
   private accessToken: string;
   private accountId: string;
   private concurrency;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Client from './client';
+import RequestClient from './client';
 import { ClientsAPI } from './api/clients';
 import { CompanyAPI } from './api/company';
 import { ContactsAPI } from './api/contacts';
@@ -29,7 +29,7 @@ export default class Harvest {
   concurrency = null;
   debug = false;
 
-  client: Client;
+  client: RequestClient;
   request;
 
   clients: ClientsAPI;
@@ -59,7 +59,7 @@ export default class Harvest {
     this.concurrency = config.concurrency || null;
     this.debug = config.debug || false;
 
-    this.client = new Client(config);
+    this.client = new RequestClient(config);
     this.request = this.requestGenerator();
 
     this.clients = new ClientsAPI(this);


### PR DESCRIPTION
When the typings were merged, the Client endpoint in harvest as well as the Request client had
conflicting names. The Request clinet has been updated to RequestClint.