### PR TITLE
Feature/retry after

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,12 @@
         "lodash": "4.17.10"
       }
     },
+    "@types/async": {
+      "version": "2.0.49",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.49.tgz",
+      "integrity": "sha512-Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==",
+      "dev": true
+    },
     "@types/detect-indent": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/detect-indent/-/detect-indent-0.1.30.tgz",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "semantic-release": "^15.1.5"
   },
   "devDependencies": {
+    "@types/async": "^2.0.49",
     "@types/jest": "^23.0.0",
     "@types/node": "^10.0.3",
+    "@types/request-promise": "^4.1.42",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "dotenv": "^6.0.0",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -125,9 +125,7 @@ describe('Client test', () => {
 
     it('should pause the queue and push the task on to it', () => {
       const task = {
-        callback: timeout => {
-          expect(timeout).toEqual('Retry after: 15');
-        }
+        callback: () => undefined
       };
       instance.retryAfter(task, 15, complete);
       expect(instance.queue.pause).toHaveBeenCalled();

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -10,6 +10,8 @@ const config = {
   }
 };
 
+jest.useFakeTimers();
+
 /**
  * Dummy test
  */
@@ -36,7 +38,7 @@ describe('Client test', () => {
 
   describe('push method', () => {
     it('should call the client push method with the request', () => {
-      spyOn(instance.queue, 'push');
+      jest.spyOn(instance.queue, 'push');
       const task = { test: true };
       instance.push(task);
       expect(instance.queue.push).toHaveBeenCalledWith(task);
@@ -55,9 +57,10 @@ describe('Client test', () => {
     });
 
     it('should recieve data and send it to the callback', done => {
-      spyOn(instance, 'request').and.callFake(() =>
-        Promise.resolve({ headers: true, data: true })
-      );
+      instance.request = jest.fn().mockResolvedValue({
+        headers: true,
+        data: true
+      });
       const task = {
         method: 'string',
         uri: 'string',
@@ -72,8 +75,8 @@ describe('Client test', () => {
       });
     });
 
-    it('should recieve an error and send it to the callback', done => {
-      spyOn(instance, 'request').and.callFake(() => Promise.reject(true));
+    it('should recieve an error and send it to the callback', () => {
+      instance.request = jest.fn().mockRejectedValue(true);
       const task = {
         method: 'string',
         uri: 'string',
@@ -83,12 +86,10 @@ describe('Client test', () => {
           expect(results).toBeUndefined();
         }
       };
-      generated(task, () => {
-        done();
-      });
+      return generated(task, jest.fn());
     });
 
-    it('should call the retryAfter method after an error with a 429 status is recieved', done => {
+    it('should call the retryAfter method after an error with a 429 status is recieved', () => {
       const task = {
         method: 'string',
         uri: 'string',
@@ -96,52 +97,54 @@ describe('Client test', () => {
         callback: undefined
       };
       const retryAfter = 15;
-      const complete = jasmine.createSpy();
-      spyOn(instance, 'request').and.callFake(() =>
-        Promise.reject({
-          statusCode: 429,
-          response: { headers: { 'retry-after': retryAfter } }
-        })
-      );
-      spyOn(instance, 'retryAfter').and.callFake(() => {
-        expect(instance.retryAfter).toHaveBeenCalledWith(task, retryAfter, complete);
-        done();
+      const complete = jest.fn();
+      instance.request = jest.fn().mockRejectedValue({
+        statusCode: 429,
+        response: { headers: { 'retry-after': retryAfter } }
       });
-      generated(task, complete);
+      instance.retryAfter = jest.fn().mockImplementation(() => {
+        expect(instance.retryAfter).toHaveBeenCalledWith(
+          task,
+          retryAfter,
+          complete
+        );
+      });
+      return generated(task, complete);
     });
   });
 
   describe('retryAfter method', () => {
-    const complete = jasmine.createSpy();
+    const complete = jest.fn();
     let pause;
     let push;
     let resume;
 
     beforeEach(() => {
-      pause = spyOn(instance.queue, 'pause').and.callFake(() => true);
-      push = spyOn(instance.queue, 'push').and.callFake(() => true);
-      resume = spyOn(instance.queue, 'resume').and.callFake(() => true);
+      instance.queue.pause = jest.fn();
+      instance.queue.unshift = jest.fn();
+      instance.queue.resume = jest.fn();
     });
 
-    it('should pause the queue and push the task on to it', () => {
+    it('should pause the queue and unshift the task on to it', () => {
       const task = {
-        callback: () => undefined
+        callback: jest.fn()
       };
       instance.retryAfter(task, 15, complete);
       expect(instance.queue.pause).toHaveBeenCalled();
-      expect(instance.queue.push).toHaveBeenCalled();
+      expect(instance.queue.unshift).toHaveBeenCalled();
+      expect(task.callback).not.toHaveBeenCalled();
     });
 
-    it('should resume the queue after the timeout is over', done => {
+    it('should resume the queue after the timeout is over', () => {
       const task = {
-        callback: jasmine.createSpy()
+        callback: jest.fn()
       };
       const retryAfter = 0.15;
       instance.retryAfter(task, retryAfter, complete);
-      setTimeout(() => {
-        expect(instance.queue.resume).toHaveBeenCalled();
-        done();
-      }, retryAfter * 1000);
+
+      jest.advanceTimersByTime(retryAfter * 1000);
+
+      expect(instance.queue.resume).toHaveBeenCalled();
     });
   });
 });

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -95,15 +95,16 @@ describe('Client test', () => {
         data: 'any',
         callback: undefined
       };
+      const retryAfter = 15;
       const complete = jasmine.createSpy();
       spyOn(instance, 'request').and.callFake(() =>
         Promise.reject({
           statusCode: 429,
-          response: { headers: { 'retry-after': 10 } }
+          response: { headers: { 'retry-after': retryAfter } }
         })
       );
       spyOn(instance, 'retryAfter').and.callFake(() => {
-        expect(instance.retryAfter).toHaveBeenCalledWith(task, 10, complete);
+        expect(instance.retryAfter).toHaveBeenCalledWith(task, retryAfter, complete);
         done();
       });
       generated(task, complete);
@@ -137,11 +138,12 @@ describe('Client test', () => {
       const task = {
         callback: jasmine.createSpy()
       };
-      instance.retryAfter(task, 15, complete);
+      const retryAfter = 0.15;
+      instance.retryAfter(task, retryAfter, complete);
       setTimeout(() => {
         expect(instance.queue.resume).toHaveBeenCalled();
         done();
-      }, 20);
+      }, retryAfter * 1000);
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import async from 'async';
+import * as async from 'async';
 import * as Request from 'request-promise';
 
 export class RequestClient {
@@ -15,7 +15,7 @@ export class RequestClient {
     this.accountId = config.auth.accountId;
 
     this.request = Request.defaults({
-      baseURL: 'https://api.harvestapp.com',
+      baseUrl: 'https://api.harvestapp.com',
       headers: {
         'User-Agent': config.userAgent,
         Authorization: `Bearer ${this.accessToken}`,
@@ -46,7 +46,7 @@ export class RequestClient {
       let options: any = {};
 
       options.method = task.method;
-      options.url = 'https://api.harvestapp.com/' + task.uri;
+      options.uri = task.uri;
 
       options.body = JSON.stringify(task.data);
 
@@ -57,22 +57,22 @@ export class RequestClient {
         })
         .catch(error => {
           if (error.statusCode === 429) {
-            this.retryAfter(
+            return this.retryAfter(
               task,
               error.response.headers['retry-after'],
               done
             );
-          } else {
-            task.callback(error, undefined);
-            done();
           }
+
+          task.callback(error, undefined);
+          done();
         });
     };
   }
 
   retryAfter(task, retryAfter, done) {
     this.queue.pause();
-    this.queue.push(task);
+    this.queue.unshift(task);
     clearTimeout(this.timeout);
 
     this.timeout = setTimeout(() => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,10 +34,6 @@ export class RequestClient {
   }
 
   preprocess(body, response) {
-    // if (headers['retry-after']) {
-    //   this.retryAfter(task, headers['retry-after'], done);
-    // }
-
     return { headers: response.headers, data: body };
   }
 
@@ -61,14 +57,15 @@ export class RequestClient {
         })
         .catch(error => {
           if (error.statusCode === 429) {
-            return this.retryAfter(
+            this.retryAfter(
               task,
               error.response.headers['retry-after'],
               done
             );
+          } else {
+            task.callback(error, undefined);
+            done();
           }
-          task.callback(error, undefined);
-          done();
         });
     };
   }
@@ -80,9 +77,7 @@ export class RequestClient {
 
     this.timeout = setTimeout(() => {
       this.queue.resume();
+      done();
     }, retryAfter * 1000);
-
-    done();
-    task.callback(`Retry after: ${retryAfter}`, undefined, undefined);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -80,7 +80,7 @@ export class RequestClient {
 
     this.timeout = setTimeout(() => {
       this.queue.resume();
-    }, retryAfter);
+    }, retryAfter * 1000);
 
     done();
     task.callback(`Retry after: ${retryAfter}`, undefined, undefined);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,8 @@
     "alwaysStrict": true,
     "baseUrl": "src",
     "lib": [
-        "es2016",
-        "dom",
-        "esnext.asynciterable"
+      "es2016",
+      "dom"
     ],
     "moduleResolution": "node",
     "target": "es6",
@@ -21,10 +20,6 @@
     "src"
   ],
   "exclude": [
-      "src/**/*.models.ts",
-      "node_modules",
-      "**/*.spec.ts",
-      "test",
-      "dist"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
Most changes are self-explanatory. To note, however, is the removal of ``task.callback(`Retry after: ${retryAfter}`, undefined, undefined);``. Since the rate limit is a controlled exception, it makes no sense to reject the promise despite the fact that it was successful after retrying. I also updated the tests to reflect this change:

```
const task = {
  callback: () => undefined
};
```

I think it's a good idea to explicitly use a no-op so that it's obvious to the reader rather than just having `const task = {}`.

Let me know what you think.