### PR TITLE
Fix #108: Export default class correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist').default;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "harvest"
   ],
   "module": "dist/index.js",
-  "main": "./",
+  "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
The typings for `"harvest"` mean I have to import it as a default:

```
import Harvest from "harvest";

const harvest = new Harvest(...)
```

This then transpiles to:

```
var harvest_1 = require("harvest");
var harvest = new harvest_1["default"]({
```

However `harvest_1` is the `Harvest` constructor itself. (thus `["default"]` is `undefined`.)

---

This changes to reference the `dist/index.js` file which **does** have a default export.