### PR TITLE
Fix #115: Use correct schema for TimeEntries.create

### DIFF
--- a/src/api/timeEntries.ts
+++ b/src/api/timeEntries.ts
@@ -1,6 +1,8 @@
 import {
   TimeEntriesPagenationParameters,
-  TimeEntry
+  TimeEntry,
+  TimeEntryCreateFromDuration,
+  TimeEntryCreateFromStartAndEndTime
 } from '../models/timeEntries.models';
 
 // Admin permissions required.
@@ -21,7 +23,7 @@ export class TimeEntriesAPI {
     return this.harvest.request('GET', this.baseUrl, query);
   }
 
-  public create(data: TimeEntry) {
+  public create(data: TimeEntryCreateFromDuration | TimeEntryCreateFromStartAndEndTime) {
     return this.harvest.request('POST', this.baseUrl, data);
   }
 

--- a/src/models/timeEntries.models.ts
+++ b/src/models/timeEntries.models.ts
@@ -151,3 +151,103 @@ export interface TimeEntriesPagenationParameters extends PagenationParameters {
    */
   to?: string;
 }
+
+/**
+ * Create a Time Entry from a duration
+ */
+export interface TimeEntryCreateFromDuration {
+  /**
+   * The ID of the project to associate with the time entry.
+   * Type: integer 
+   */
+  project_id: number;
+  
+  /**
+   * The ID of the task to associate with the time entry.
+   * Type: integer 
+   */
+  task_id: number;
+  
+  /**
+   * The ISO 8601 formatted date the time entry was spent.
+   * Type: date 
+   */
+  spent_date: string;
+  
+  /**
+   * The ID of the user to associate with the time entry. Defaults to the currently authenticated user’s ID.
+   * Type: integer 
+   */
+  user_id?: number;
+  
+  /**
+   * The current amount of time tracked. If provided, `is_running` on the time entry will be true.
+   * Type: decimal 
+   */
+  hours?: number;
+  
+  /**
+   * Any notes to be associated with the time entry.
+   * Type: string 
+   */
+  notes?: string;
+  
+  /**
+   * An object containing the `id`, `group_id`, and `permalink` of the external reference.
+   * Type: object 
+   */
+  external_reference?: any;
+}
+
+/**
+ * Create a Time Entry from a start and end time
+ */
+export interface TimeEntryCreateFromStartAndEndTime {
+  /**
+   * The ID of the project to associate with the time entry.
+   * Type: integer 
+   */
+  project_id: number;
+  
+  /**
+   * The ID of the task to associate with the time entry.
+   * Type: integer 
+   */
+  task_id: number;
+  
+  /**
+   * The ISO 8601 formatted date the time entry was spent.
+   * Type: date 
+   */
+  spent_date: string;
+  
+  /**
+   * The ID of the user to associate with the time entry. Defaults to the currently authenticated user’s ID.
+   * Type: integer 
+   */
+  user_id?: number;
+  
+  /**
+   * The time the entry started. Defaults to the current time. Example: "8:00am".
+   * Type: time 
+   */
+  started_time?: string;
+  
+  /**
+   * The time the entry ended. If provided, `is_running` on the time entry will be false.
+   * Type: time 
+   */
+  ended_time?: string;
+
+  /**
+   * Any notes to be associated with the time entry.
+   * Type: string 
+   */
+  notes?: string;
+  
+  /**
+   * An object containing the `id`, `group_id`, and `permalink` of the external reference.
+   * Type: object 
+   */
+  external_reference?: any;
+}

--- a/src/models/timeEntries.models.ts
+++ b/src/models/timeEntries.models.ts
@@ -112,7 +112,7 @@ export interface TimeEntriesPagenationParameters extends PagenationParameters {
   user_id?: number;
 
   /**
-   * OOnly return time entries belonging to the client with the given ID.
+   * Only return time entries belonging to the client with the given ID.
    * Type: integer.
    */
   client_id?: number;


### PR DESCRIPTION
This PR introduces two interfaces, `TimeEntryCreateFromDuration` and `TimeEntryCreateFromStartAndEndTime` which correctly match the two options for creating a Time Entry.