### PR TITLE
Make accountId a number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export interface Config {
   debug?: boolean;
   auth: {
     accessToken: string;
-    accountId: string;
+    accountId: number;
   };
 }
 


### PR DESCRIPTION
`accountId` is a `number`, but I accidentally made it a `string` when I made the `Config` interface.