### PR TITLE
fix: correctly pass query args to GET endpoints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -60,7 +60,11 @@ export class RequestClient {
       options.method = task.method;
       options.uri = task.uri;
 
-      options.body = JSON.stringify(task.data);
+      if (task.method === 'GET') {
+        options.qs = task.data;
+      } else {
+        options.body = JSON.stringify(task.data);
+      }
 
       this.request(options)
         .then(({ headers, data }) => {


### PR DESCRIPTION
Previously the query args for the GET endpoints weren't correctly passed, this fixes that issue.

Fixes: https://github.com/simplyspoke/node-harvest/issues/219
